### PR TITLE
Fix invalidation address and non power of 2 fifos

### DIFF
--- a/core/common_components/cva5_fifo.sv
+++ b/core/common_components/cva5_fifo.sv
@@ -100,7 +100,7 @@ module cva5_fifo
         end
 
         assign fifo.valid = inflight_count[LOG2_FIFO_DEPTH];
-        assign fifo.full = fifo.valid & ~|inflight_count[LOG2_FIFO_DEPTH-1:0];
+        assign fifo.full = inflight_count == -FIFO_DEPTH[LOG2_FIFO_DEPTH:0];
 
         lfsr #(.WIDTH(LOG2_FIFO_DEPTH), .NEEDS_RESET(1))
         lfsr_read_index (

--- a/core/common_components/cva5_fifo.sv
+++ b/core/common_components/cva5_fifo.sv
@@ -100,7 +100,7 @@ module cva5_fifo
         end
 
         assign fifo.valid = inflight_count[LOG2_FIFO_DEPTH];
-        assign fifo.full = inflight_count == -FIFO_DEPTH[LOG2_FIFO_DEPTH:0];
+        assign fifo.full = inflight_count == (LOG2_FIFO_DEPTH+1)'(-FIFO_DEPTH);
 
         lfsr #(.WIDTH(LOG2_FIFO_DEPTH), .NEEDS_RESET(1))
         lfsr_read_index (

--- a/core/execution_units/branch_unit.sv
+++ b/core/execution_units/branch_unit.sv
@@ -138,13 +138,11 @@ module branch_unit
     end
     ////////////////////////////////////////////////////
 
-    logic jal;
     logic jalr;
     logic jal_or_jalr;
     logic br_use_signed;
     always_ff @(posedge clk) begin
         if (issue_stage_ready) begin
-            jal <= decode_stage.instruction[3];
             jalr <= (~decode_stage.instruction[3] & decode_stage.instruction[2]);
             jal_or_jalr <= decode_stage.instruction[2];
             br_use_signed <= !(instruction.fn3 inside {BLTU_fn3, BGEU_fn3});

--- a/l2_arbiter/axi_to_arb.sv
+++ b/l2_arbiter/axi_to_arb.sv
@@ -201,10 +201,10 @@ module axi_to_arb
 
     //write channel
     logic write_request;
+    logic write_in_progress_r;
     assign write_request = l2.wr_data_valid & l2.request_valid & (~l2.rnw | amo_write_ready);
     assign axi_awvalid = write_request & ~write_in_progress_r;
 
-    logic write_in_progress_r;
     always_ff @ (posedge clk) begin
         if (rst)
             write_in_progress_r <= 0;

--- a/l2_arbiter/l2_arbiter.sv
+++ b/l2_arbiter/l2_arbiter.sv
@@ -230,7 +230,7 @@ module l2_arbiter
             //Arbiter side
             assign inv_response_fifos[i].push = reserv_valid & reserv_store  & ~reserv_id_v[i];
             assign inv_response_fifos[i].potential_push = reserv_valid & reserv_store  & ~reserv_id_v[i];
-            assign inv_response_fifos[i].data_in = requests[i].addr;
+            assign inv_response_fifos[i].data_in = reserv_request.addr;
         end
     endgenerate
 


### PR DESCRIPTION
The first fix addresses L1 cache invalidation in the L2 arbiter. Currently, for each unit connected to the arbiter, the arbiter invalidates _each units own current address_ instead of _the address of the arbitrated unit_.

Currently the depth of FIFOs are implicitly rounded up to the nearest power of 2. Although the processor currently doesn't contain any FIFOs with a non power of 2 depth, this implicit rounding up can cause problems when extending the processor.
This second change makes the FIFO behave as if it has the specified depth. For example, a FIFO with a configured depth of 11 will state that it is full when it contains 11 entries (even if it actually has capacity for 16).