### PR TITLE
solving two problems related to the interrupt + mret,sret instructions

### DIFF
--- a/core/execution_units/csr_unit.sv
+++ b/core/execution_units/csr_unit.sv
@@ -619,7 +619,7 @@ end
         .encoded_result (mip_cause_sel)
     );
 
-    always_ff @(posedge clk) begin
+    always_comb begin
         if (interrupt_pending)
             interrupt_cause_r <= interruput_code_table[mip_cause_sel];
     end

--- a/core/execution_units/csr_unit.sv
+++ b/core/execution_units/csr_unit.sv
@@ -601,7 +601,7 @@ end
     logic [5:0] mip_priority_vector;
     logic [2:0] mip_cause_sel;
 
-    localparam logic [ECODE_W-1:0] interruput_code_table [7:0] = '{ 0, 0, 
+    localparam logic [ECODE_W-1:0] interrupt_code_table [7:0] = '{ 0, 0, 
         S_TIMER_INTERRUPT, S_SOFTWARE_INTERRUPT, S_EXTERNAL_INTERRUPT,
         M_TIMER_INTERRUPT, M_SOFTWARE_INTERRUPT, M_EXTERNAL_INTERRUPT
     };

--- a/core/execution_units/gc_unit.sv
+++ b/core/execution_units/gc_unit.sv
@@ -380,8 +380,7 @@ generate if (CONFIG.MODES != BARE) begin : gen_gc_m_mode
     assign gc.exception.valid = |exception_valid;
     assign gc.exception.source = exception_valid;
 
-    assign interrupt_taken = interrupt_pending & (next_state == PRE_ISSUE_FLUSH) & ~(gc.exception.valid) & ~csr_frontend_flush & ~(issue.new_request & ~is_wfi & ~new_exception);
-
+    assign interrupt_taken = interrupt_pending & (current_state == WAIT_INTERRUPT) & (next_state == PRE_ISSUE_FLUSH) & ~gc.exception.valid & ~csr_frontend_flush;
     //Writeback and rename handling
     logic gc_writeback_suppress_r;
     logic gc_rename_revert;

--- a/core/execution_units/gc_unit.sv
+++ b/core/execution_units/gc_unit.sv
@@ -380,7 +380,7 @@ generate if (CONFIG.MODES != BARE) begin : gen_gc_m_mode
     assign gc.exception.valid = |exception_valid;
     assign gc.exception.source = exception_valid;
 
-    assign interrupt_taken = interrupt_pending & (current_state == WAIT_INTERRUPT) & (next_state == PRE_ISSUE_FLUSH) & ~gc.exception.valid & ~csr_frontend_flush;
+    assign interrupt_taken = interrupt_pending & (state == WAIT_INTERRUPT) & (next_state == PRE_ISSUE_FLUSH) & ~gc.exception.valid & ~csr_frontend_flush;
     //Writeback and rename handling
     logic gc_writeback_suppress_r;
     logic gc_rename_revert;

--- a/core/execution_units/gc_unit.sv
+++ b/core/execution_units/gc_unit.sv
@@ -380,7 +380,7 @@ generate if (CONFIG.MODES != BARE) begin : gen_gc_m_mode
     assign gc.exception.valid = |exception_valid;
     assign gc.exception.source = exception_valid;
 
-    assign interrupt_taken = interrupt_pending & (next_state == PRE_ISSUE_FLUSH) & ~(gc.exception.valid) & ~csr_frontend_flush;
+    assign interrupt_taken = interrupt_pending & (next_state == PRE_ISSUE_FLUSH) & ~(gc.exception.valid) & ~csr_frontend_flush & ~(issue.new_request & ~is_wfi & ~new_exception);
 
     //Writeback and rename handling
     logic gc_writeback_suppress_r;


### PR DESCRIPTION
The first issue was that interrupt_cause_r lagged one cycle behind interrupt_pending. As a result, the previous interrupt cause was incorrectly used for delegation, which led to unexpected behavior.

The second issue occurred when an sret instruction coincided with an interrupt, causing the CPU to halt.